### PR TITLE
scale percentiles by time-unit too

### DIFF
--- a/graphite.go
+++ b/graphite.go
@@ -100,7 +100,7 @@ func graphite(c *GraphiteConfig) error {
 			fmt.Fprintf(w, "%s.%s.std-dev %.2f %d\n", c.Prefix, name, t.StdDev()/du, now)
 			for psIdx, psKey := range c.Percentiles {
 				key := strings.Replace(strconv.FormatFloat(psKey*100.0, 'f', -1, 64), ".", "", 1)
-				fmt.Fprintf(w, "%s.%s.%s-percentile %.2f %d\n", c.Prefix, name, key, ps[psIdx], now)
+				fmt.Fprintf(w, "%s.%s.%s-percentile %.2f %d\n", c.Prefix, name, key, ps[psIdx]/du, now)
 			}
 			fmt.Fprintf(w, "%s.%s.one-minute %.2f %d\n", c.Prefix, name, t.Rate1(), now)
 			fmt.Fprintf(w, "%s.%s.five-minute %.2f %d\n", c.Prefix, name, t.Rate5(), now)


### PR DESCRIPTION
Currently the min/max/mean/etc values sent to graphite are scaled
by the configured duration unit, so that one can choose what unit
the numbers sent to graphite represent, but the percentile values
are sent unscaled. This change applies the same scaling to them.
