### PR TITLE
More reliable recording

### DIFF
--- a/graphite.go
+++ b/graphite.go
@@ -111,6 +111,8 @@ func graphite(c *GraphiteConfig) error {
 			fmt.Fprintf(w, "%s.%s.five-minute %.2f %d\n", c.Prefix, name, t.Rate5(), now)
 			fmt.Fprintf(w, "%s.%s.fifteen-minute %.2f %d\n", c.Prefix, name, t.Rate15(), now)
 			fmt.Fprintf(w, "%s.%s.mean-rate %.2f %d\n", c.Prefix, name, t.RateMean(), now)
+		default:
+			log.Printf("unable to record metric of type %T\n", i)
 		}
 		w.Flush()
 	})

--- a/graphite.go
+++ b/graphite.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rcrowley/go-metrics"
+	"github.com/etsy/go-metrics"
 )
 
 // GraphiteConfig provides a container with configuration parameters for

--- a/graphite.go
+++ b/graphite.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/etsy/go-metrics"
+	"github.com/rcrowley/go-metrics"
 )
 
 // GraphiteConfig provides a container with configuration parameters for

--- a/graphite_test.go
+++ b/graphite_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/etsy/go-metrics"
+	"github.com/rcrowley/go-metrics"
 )
 
 func floatEquals(a, b float64) bool {

--- a/graphite_test.go
+++ b/graphite_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rcrowley/go-metrics"
+	"github.com/etsy/go-metrics"
 )
 
 func floatEquals(a, b float64) bool {


### PR DESCRIPTION
You won't want 9e103f5, but I can't easily exclude it. Sorry bout that.

The count_ps stats match how StatsD aggregates, and helps when your FlushInterval isn't 1s.  And the error logging makes dependency problems easier to track down.