### PR TITLE
More reliable recording

### DIFF
--- a/graphite.go
+++ b/graphite.go
@@ -111,6 +111,8 @@ func graphite(c *GraphiteConfig) error {
 			fmt.Fprintf(w, "%s.%s.five-minute %.2f %d\n", c.Prefix, name, t.Rate5(), now)
 			fmt.Fprintf(w, "%s.%s.fifteen-minute %.2f %d\n", c.Prefix, name, t.Rate15(), now)
 			fmt.Fprintf(w, "%s.%s.mean-rate %.2f %d\n", c.Prefix, name, t.RateMean(), now)
+		default:
+			log.Printf("unable to record metric of type %T\n", i)
 		}
 		w.Flush()
 	})


### PR DESCRIPTION
The count_ps stats match how StatsD aggregates, and helps when your FlushInterval isn't 1s. And the error logging makes dependency problems easier to track down.

(this supersedes #6 with just the important patches)