### PR TITLE
Add `WithConfigByReference` function.

### DIFF
--- a/graphite.go
+++ b/graphite.go
@@ -40,8 +40,14 @@ func Graphite(r metrics.Registry, d time.Duration, prefix string, addr *net.TCPA
 // WithConfig is a blocking exporter function just like Graphite,
 // but it takes a GraphiteConfig instead.
 func WithConfig(c Config) {
-	for _ = range time.Tick(c.FlushInterval) {
-		if err := graphite(&c); nil != err {
+	WithConfigByReference(&c)
+}
+
+// WithConfigByReference is a blocking exporter function just like Graphite,
+// but it takes a *GraphiteConfig instead.
+func WithConfigByReference(c *Config) {
+	for range time.Tick(c.FlushInterval) {
+		if err := graphite(c); nil != err {
 			log.Println(err)
 		}
 	}


### PR DESCRIPTION
Allow running with a pointer to a config. We specifically use this functionality to dynamically change `Prefix` as kubernetes pods are scaled up and down.

This is a non-breaking change as the original `WithConfig` signature and behavior are unchanged.