### PR TITLE
Add config to clear the counter on flush

### DIFF
--- a/graphite.go
+++ b/graphite.go
@@ -21,7 +21,7 @@ type Config struct {
 	DurationUnit  time.Duration    // Time conversion unit for durations
 	Prefix        string           // Prefix to be prepended to metric names
 	Percentiles   []float64        // Percentiles to export from timers and histograms
-	ClearOnFlush  bool             // Whether to clear on flush (Default is false)
+	ClearCountOnFlush  bool             // Whether to clear on flush (Default is false)
 }
 
 // Graphite is a blocking exporter function which reports metrics in r
@@ -39,7 +39,7 @@ func Graphite(r metrics.Registry, d time.Duration, prefix string, addr *net.TCPA
 		DurationUnit:  time.Nanosecond,
 		Prefix:        prefix,
 		Percentiles:   []float64{0.5, 0.75, 0.95, 0.99, 0.999},
-		ClearOnFlush:  c,
+		ClearCountOnFlush:  c,
 	})
 }
 
@@ -76,7 +76,7 @@ func graphite(c *Config) error {
 			count := metric.Count()
 			fmt.Fprintf(w, "%s.%s.count %d %d\n", c.Prefix, name, count, now)
 			fmt.Fprintf(w, "%s.%s.count_ps %.2f %d\n", c.Prefix, name, float64(count)/flushSeconds, now)
-			if c.ClearOnFlush {
+			if c.ClearCountOnFlush {
 				metric.Clear()
 			}
 		case metrics.Gauge:

--- a/graphite.go
+++ b/graphite.go
@@ -30,7 +30,7 @@ type Config struct {
 func Graphite(r metrics.Registry, d time.Duration, prefix string, addr *net.TCPAddr, clear ...bool) {
 	c := false
 	if len(clear) > 0 {
-		c = clear[1] // Ignore any extra parameters...
+		c = clear[0] // Ignore any extra parameters...
 	}
 	WithConfig(Config{
 		Addr:          addr,


### PR DESCRIPTION
To address: https://github.com/cyberdelia/go-metrics-graphite/issues/5

The only testing I've done was changing the ClearOnFlush flag on my own private projects. I'm still very new to Golang.

First part of the chart shows when the flag is set to true, second part when it is not set (eg. defaulting to false)

<img width="435" alt="screen shot 2018-09-27 at 5 05 16 pm" src="https://user-images.githubusercontent.com/5224106/46180861-ae8a5c00-c277-11e8-9b43-2e492d9d4f1d.png">
